### PR TITLE
Refactoring the Voltage Field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,19 +27,19 @@ pub mod circuit_graph {
         pub fn new(voltage: Option<T>, tag: u32, vertex_type: VertexType) -> Self {
             match vertex_type {
                 VertexType::Internal => {
-                    return Self {
+                    Self {
                         voltage: None,
                         tag,
                         vertex_type,
-                    };
+                    }
                 }
                 _ => {
                     assert!(!voltage.is_none());
-                    return Self {
+                    Self {
                         voltage,
                         tag,
                         vertex_type,
-                    };
+                    }
                 }
             }
         }


### PR DESCRIPTION
This closes #6. It was chosen to just use an `Option` instead of a `Cell` since `petgraph` allows mutable access to the weights just as easily as immutable access. Additionally, the constructor for `VertexMetadata` was modified to enforce that source and sink nodes have a voltage associated, and that internal nodes have none.